### PR TITLE
fix to issue #60: broken link in ch 2: the section called “Truthy and Falsy Things”

### DIFF
--- a/book/html/index.html
+++ b/book/html/index.html
@@ -519,7 +519,7 @@ baz &amp;&amp; foo;   // returns 1, which is true
               Though it may not be clear from the example, the <code class="code">||</code> operator returns the value of the first truthy operand, or, in cases where neither operand is truthy, it'll return the last of both operands. The <code class="code">&amp;&amp;</code> operator returns the value of the first false operand, or the value of the last operand if both operands are truthy.
             </p>
             <p>
-              Be sure to consult <a title="Truthy and Falsy Things" href="#javascript-basics.sections.truthy-falsy" class="xref">the section called “Truthy and Falsy Things”</a> for more details on which values evaluate to <code class="code">true</code> and which evaluate to <code class="code">false</code>.
+              Be sure to consult <a title="Truthy and Falsy Things" href="#Truthy and Falsy Things">the section called “Truthy and Falsy Things”</a> for more details on which values evaluate to <code class="code">true</code> and which evaluate to <code class="code">false</code>.
             </p>
             <div class="note">
             <h3 class="title">
@@ -621,7 +621,7 @@ if (bar) {
           </p>
           </div>
 
-          <div title="Truthy and Falsy Things" class="section">
+          <div title="Truthy and Falsy Things" id="Truthy and Falsy Things" class="section">
             <div class="titlepage">
               <h3 class="title">
                 Truthy and Falsy Things


### PR DESCRIPTION
• added an ID so the link works
• removed what looked like an outdated/extraneous class ('xref')

woot!
