### PR TITLE
Fix mdash in Functions as Arguments section

### DIFF
--- a/book/part1-javascript-101/ch02-javascript-basics.html
+++ b/book/part1-javascript-101/ch02-javascript-basics.html
@@ -1060,7 +1060,7 @@ console.log(foo);   // undefined!
                 </h3>
               </div>
               <p>
-                In JavaScript, functions are "first-class citizens" &mdash they can be assigned to variables or passed to other functions as arguments. Passing functions as arguments is an extremely common idiom in jQuery.
+                In JavaScript, functions are "first-class citizens" &mdash; they can be assigned to variables or passed to other functions as arguments. Passing functions as arguments is an extremely common idiom in jQuery.
               </p>
               <div class="example">
                 <p class="title">


### PR DESCRIPTION
Hi,

You might want to redo the change in this pull request - it's my first and I can't work out if I've screwed up the end of the file. Hopefully it should give you an idea of what's missing. Within the Functions as Arguments section there's an &amp;mdash with a missing ; so it shows in the html

chanoch
